### PR TITLE
Adding a concurrency-run property so workflows don't launch 3x

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    concurrency: docker-build-${{ github.ref }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Adding a concurrency-run property so workflows don't launch 3x